### PR TITLE
Fixed the tab bar colors

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -180,9 +180,9 @@ if version >= 700
   hi! link CursorColumn CursorLine
 
   " Tab pages line filler
-  call s:HL('TabLineFill', s:black, s:black)
+  call s:HL('TabLineFill', s:green, s:black)
   " Active tab page label
-  call s:HL('TabLineSel', s:black, s:black, s:bold)
+  call s:HL('TabLineSel', s:red, s:black, s:bold)
   " Not active tab page label
   hi! link TabLine TabLineFill
 


### PR DESCRIPTION
Previously the tab bar didn't show any entries, since both the
text color and background were black.

I use neovim 0.1.5 on arch linux, not sure whether this is an issue