### PR TITLE
Added custom color for the built-in terminal

### DIFF
--- a/colors/srcery.vim
+++ b/colors/srcery.vim
@@ -465,6 +465,15 @@ if has('spell')
 endif
 
 " }}}
+" Terminal: {{{
+
+if has('terminal')
+  " Must set an explicit background as NONE won't work
+  " Therefore not useful with transparent background option
+  call s:HL('Terminal', s:bright_white, s:hard_black)
+endif
+
+" }}}
 " CtrlP: "{{{
 hi! link CtrlPMatch SrceryMagenta
 hi! link CtrlPLinePre SrceryBrightGreen


### PR DESCRIPTION
[Announced](https://www.vim.org/vim-8.1-released.php) with Vim 8.1.

<img width="1920" alt="screen shot 2018-05-23 at 14 58 50" src="https://user-images.githubusercontent.com/33870508/40426937-9e1c6f1e-5e9c-11e8-921d-91a5d992ae4f.png">